### PR TITLE
fix: events page _id problem solved

### DIFF
--- a/OSW-frontend/src/components/Event/Events.js
+++ b/OSW-frontend/src/components/Event/Events.js
@@ -76,7 +76,7 @@ const Events = () => {
         console.log(error.message);
       }
     };
-    if (user._id && user._id !== "") {
+    if (user?._id && user?._id !== "") {
       fetchUserProfile();
     }
   }, [user]);


### PR DESCRIPTION
![image](https://github.com/oscf-io/OSWeekend-Web/assets/76242769/bd131895-4454-41b6-9f6f-61ef21a0f2b7)

Event page working fine